### PR TITLE
fix: update link for devops roadmap

### DIFF
--- a/DevOps/README.md
+++ b/DevOps/README.md
@@ -2,7 +2,7 @@
 
 ### Getting Started
 
-* [DevOps Roadmap](https://github.com/kamranahmedse/developer-roadmap/blob/master/img/devops.png)
+* [DevOps Roadmap](https://roadmap.sh/devops)
 * [Learn bash scripting](https://www.codecademy.com/learn/learn-the-command-line/modules/bash-scripting)
 * [Advanced Bash616](http://tldp.org/LDP/abs/html/index.html)
 


### PR DESCRIPTION
- changed to roadmap.sh link instead of broken github repo link